### PR TITLE
Allow copying from another file/directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,11 @@ selinux::filecontext { '/srv/foo.txt':
 }
 ```
 
+To copy the context from another file, set copy to true and 'seltype' to the source file:
+
+```puppet
+selinux::filecontext { '/export/home':
+  seltype => '/home',
+  copy    => true,
+}
+```

--- a/manifests/filecontext.pp
+++ b/manifests/filecontext.pp
@@ -6,6 +6,7 @@ define selinux::filecontext (
   $seltype,
   $object  = $title,
   $recurse = false,
+  $copy = false,
 ) {
 
   if $::selinux {
@@ -22,12 +23,16 @@ define selinux::filecontext (
       true  => '-d',
       false => '-e',
     }
+    $copy_options = $copy ? {
+      true  => '-e',
+      false => '-t',
+    }
 
     # Run semanage to persistently set the SELinux Type.
     # Note that changes made by semanage do not take effect
     # until an explicit relabel is performed.
     exec { "semanage_fcontext_${seltype}_${object}":
-      command => "semanage fcontext -a -t ${seltype} '${target}'",
+      command => "semanage fcontext -a ${copy_options} ${seltype} '${target}'",
       path    => [ '/bin', '/usr/bin', '/sbin', '/usr/sbin' ],
       unless  => "semanage fcontext -l -C -n | grep ^${object}",
       require => Package['audit2allow'],


### PR DESCRIPTION
This allows just copying permissions from another directory. This is useful as in the example of a different location for the home directories.